### PR TITLE
Correct some N+1s

### DIFF
--- a/app/controllers/api/games_controller.rb
+++ b/app/controllers/api/games_controller.rb
@@ -2,7 +2,7 @@ class Api::GamesController < ApplicationController
   before_action :authenticate_player
 
   def index
-    @games = Game.all.order(:date_time)
+    @games = Game.includes(:players, :field).order(:date_time)
     render "index.json.jb"
   end
 

--- a/app/controllers/api/players_controller.rb
+++ b/app/controllers/api/players_controller.rb
@@ -1,6 +1,6 @@
 class Api::PlayersController < ApplicationController
   def index
-    @players = Player.all
+    @players = Player.all.includes(:games_attending, :games_created)
     render "index.json.jb"
   end
 


### PR DESCRIPTION
Use `includes` for associations where they'e getting called for each individual item.

The idea here that in `app/views/api/games/index.json.jb` and `app/views/api/players/index.json.jb` the code calls on some associations, and using `includes` can pre-load them, saving many trips to the database.

Cases where this was happening:
* `GamesController#index`
* `PlayersController#index`